### PR TITLE
Support an additional use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## terraform-aws-pipeline-error-catcher
 A Terraform module that creates a Lambda function that can be used inside an AWS Step Function to check if any errors occured in a previous parallel state. One of the inputs to the Lambda, `fail_on_errors`, determines if the Lambda should stop the Step Function execution if an error has occured, or if it simply should return a boolean.
 
+An _error_ is in this context defined as a JSON object that contains the two keys `Error` and `Cause` -- the format used by AWS Step Functions for errors.
+
 ## Lambda inputs
 
 #### `input` (required)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 ## terraform-aws-pipeline-error-catcher
 A Terraform module that creates a Lambda function that can be used inside an AWS Step Function to check if any errors occured in a previous parallel state. One of the inputs to the Lambda, `fail_on_errors`, determines if the Lambda should stop the Step Function execution if an error has occured, or if it simply should return a boolean.
 
+## Lambda inputs
+
+#### `input` (required)
+A list of outputs from a set of branches in a parallel state.
+
+#### `token` (required)
+A Step Function token used to report back success or failure.
+
+#### `error_key` (optional)
+If `error_key` is set, the Lambda expects each element in the `input` list to expose its error object under the given key. If no such key is provided, the Lambda expects each list element to be an error object.
+
+#### `fail_on_errors` (optional)
+By default, the error catching state will fail if any errors are found in the `input` variable. This can be disabled by setting `fail_on_errors` to `false`, in which the state will report success and output a boolean reflecting if errors were found or not.
+
 ## Example
 Add the module to your Terraform code:
 ```terraform
@@ -21,7 +35,7 @@ A minimal example of a state machine definition that uses the Lambda function cr
       "Comment": "A parallel state",
       "Type": "Parallel",
       "Next": "Check for Errors",
-      "ResultPath": "$.Result",
+      "ResultPath": "$.result",
       "Branches": [
         {
           "StartAt": "Do Stuff (Branch 1)",
@@ -80,7 +94,7 @@ A minimal example of a state machine definition that uses the Lambda function cr
         "FunctionName": "pipeline-error-catcher",
         "Payload":  {
           "token.$": "$$.Task.Token",
-          "input.$": "$.Result",
+          "input.$": "$.result",
           "fail_on_errors": true,
           "error_key": "errors"
         }

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ def get_errors(json_input, error_key):
     for element in json_input:
         if error_key in element:
             error = element[error_key]
-        elif all(key in ["Error", "Cause"] for key in element):
+        elif all(key in element for key in ["Error", "Cause"]):
             error = element
         else:
             continue

--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,7 @@ def lambda_handler(event, context):
     logger.info("Lambda triggered with event '%s'", event)
     token = event["token"]
     fail_on_errors = event.get("fail_on_errors", True)
-    error_key = event.get("error_key", "errors")
+    error_key = event.get("error_key", "")
     json_input = event["input"]
 
     client = boto3.client("stepfunctions")

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ logger.setLevel(logging.INFO)
 
 
 def get_errors(json_input, error_key):
+    """Return the error objects (objects containing both an "Error" and a "Cause" key) found in the input JSON"""
     errors = []
     for element in json_input:
         if error_key and all(key in element.get(error_key, {}) for key in ["Error", "Cause"]):

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ logger.setLevel(logging.INFO)
 def get_errors(json_input, error_key):
     errors = []
     for element in json_input:
-        if error_key and error_key in element:
+        if error_key and all(key in element.get(error_key, {}) for key in ["Error", "Cause"]):
             error = element[error_key]
         elif all(key in element for key in ["Error", "Cause"]):
             error = element

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ logger.setLevel(logging.INFO)
 def get_errors(json_input, error_key):
     errors = []
     for element in json_input:
-        if error_key in element:
+        if error_key and error_key in element:
             error = element[error_key]
         elif all(key in element for key in ["Error", "Cause"]):
             error = element

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,19 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
+def get_errors(json_input, error_key):
+    errors = []
+    for element in json_input:
+        if error_key in element:
+            error = element[error_key]
+        elif all(key in ["Error", "Cause"] for key in element):
+            error = element
+        else:
+            continue
+        errors.append(error)
+    return errors
+
+
 def lambda_handler(event, context):
     logger.info("Lambda triggered with event '%s'", event)
     token = event["token"]
@@ -28,9 +41,7 @@ def lambda_handler(event, context):
             f"Expected the input to be a list, not {type(json_input)}"
         )
 
-    errors = [
-        result[error_key] for result in json_input if error_key in result
-    ]
+    errors = get_errors(json_input, error_key)
 
     if fail_on_errors and len(errors):
         error_codes = "|".join(error["Error"] for error in errors)

--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def lambda_handler(event, context):
     client = boto3.client("stepfunctions")
     if not isinstance(json_input, list):
         raise ValueError(
-            f"Expected the input to be a list, not {type(json_input)}"
+            f"Expected the input to be a list containing the outputs of each branch in a parallel state, but got type '{type(json_input)}'"
         )
 
     errors = get_errors(json_input, error_key)

--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,7 @@ def lambda_handler(event, context):
         )
 
     errors = get_errors(json_input, error_key)
+    logger.info("Found errors %s", errors)
 
     if fail_on_errors and len(errors):
         error_codes = "|".join(error["Error"] for error in errors)


### PR DESCRIPTION
Allow list elements in `input` to be the actual error objects, instead of having the error object nested under a specific key. This is helpful if you catch errors without using `ResultPath`.